### PR TITLE
feat: add docker development stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ dist
 # Temporary folders
 tmp/
 temp/
+apps/api/tmp/
 
 # Go specific
 # Binaries for programs and plugins

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,94 @@
+# Local Development with Docker
+
+This repository now ships with a Docker-based development environment that mirrors production while keeping the feedback loop fast. The setup runs the PostgreSQL database, the Go API (with hot reload via [Air](https://github.com/air-verse/air)), and the Next.js web app (with hot reload) on your machine.
+
+## Prerequisites
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) 4.20+ or Docker Engine 24+
+- Docker Compose v2 (bundled with modern Docker Desktop)
+
+> **Tip:** The stack binds to local ports `3000` (web), `8080` (API), and `5432` (database). Make sure those ports are free before starting.
+
+## Quick Start
+
+```bash
+docker compose -f docker-compose.dev.yml up --build
+```
+
+- The **web app** is available at [http://localhost:3000](http://localhost:3000)
+- The **API** is available at [http://localhost:8080](http://localhost:8080)
+- PostgreSQL listens on `localhost:5432` with user `postgres` / password `postgres`
+
+The first run installs dependencies and can take a few minutes. Subsequent runs are much faster thanks to persistent Docker volumes for the Go build cache, pnpm store, and database data.
+
+To stop everything press `Ctrl+C` (foreground) or run:
+
+```bash
+docker compose -f docker-compose.dev.yml down
+```
+
+To remove the development database and caches, add `--volumes`:
+
+```bash
+docker compose -f docker-compose.dev.yml down --volumes
+```
+
+## Hot Reload Behaviour
+
+- **API (`apps/api`)** – The service installs the Air hot reload daemon on first boot and re-builds the Go server whenever `.go`, `.sql`, `.yaml`, or `.json` files change. Files under `apps/api/tmp`, `uploads`, and `test_escape` are ignored.
+- **Web (`apps/web`)** – Next.js runs in development mode with polling enabled so changes made on the host are reflected instantly. A named Docker volume keeps `node_modules` separate from your working tree.
+
+## Default Environment Variables
+
+The compose file provides sensible defaults for local development:
+
+| Service | Variable | Default |
+| ------- | -------- | ------- |
+| Database | `POSTGRES_USER` | `postgres` |
+| Database | `POSTGRES_PASSWORD` | `postgres` |
+| Database | `POSTGRES_DB` | `it_tms` |
+| API | `DATABASE_URL` | `postgres://postgres:postgres@db:5432/it_tms?sslmode=disable` |
+| API | `JWT_SECRET` | `dev-secret-change-me-please-1234567890` |
+| API | `CORS_ALLOWED_ORIGINS` | `http://localhost:3000` |
+| API | `WS_ALLOWED_ORIGINS` | `http://localhost:3000` |
+| API | `WEB_APP_URL` | `http://localhost:3000` |
+| Web | `NEXT_PUBLIC_API_URL` | `http://localhost:8080` |
+| Web | `NEXT_PUBLIC_WS_URL` | `ws://localhost:8080/ws` |
+| Web | `NEXT_PUBLIC_SOCKET_URL` | `ws://localhost:8080/ws` |
+
+Override any value by defining the variable in your shell or in a `.env` file next to `docker-compose.dev.yml` before running `docker compose`.
+
+## Seed Data
+
+On startup the `db-seed` job runs `apps/api/cmd/seed/main.go`. It ensures a useful set of demo users exists and clears development-only data. Sign in with any of these credentials:
+
+- Manager: `peachchan@demo.com` / `Password!1`
+- Supervisor: `saroge@demo.com` / `Password!1`
+- User: `manit@demo.com` / `Password!1`
+
+You can re-run the seeder at any time:
+
+```bash
+docker compose -f docker-compose.dev.yml run --rm db-seed
+```
+
+## Running Workspace Commands
+
+Execute additional commands inside the running containers:
+
+- Run API tests:
+  ```bash
+  docker compose -f docker-compose.dev.yml exec api go test ./...
+  ```
+- Run web linting:
+  ```bash
+  docker compose -f docker-compose.dev.yml exec web pnpm --filter @it-tms/web lint
+  ```
+
+## Troubleshooting
+
+- If the API fails to compile, check the terminal running `docker compose` for Air logs.
+- Next.js dev server binds to `0.0.0.0:3000`. If the browser cannot connect, ensure your firewall allows localhost traffic.
+- Remove cached volumes if dependencies act up: `docker compose -f docker-compose.dev.yml down --volumes`.
+
+Happy hacking! 🎉

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7-labs
+
+ARG PNPM_VERSION=9.12.0
+
+FROM node:20-alpine AS base
+WORKDIR /workspace
+
+# Install useful tooling for local development
+RUN apk add --no-cache bash git openssh-client curl libc6-compat
+
+# Enable corepack and pin pnpm for reproducibility
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+
+ENV PNPM_HOME="/root/.local/share/pnpm"
+ENV PATH="${PNPM_HOME}:${PATH}"
+ENV NODE_ENV=development
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV WATCHPACK_POLLING=true
+ENV CHOKIDAR_USEPOLLING=true
+
+# Copy manifest files so pnpm can warm the store during image build
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY apps/web/package.json apps/web/package.json
+COPY packages/ui/package.json packages/ui/package.json
+
+# Warm pnpm store to speed up installs when the container starts
+RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+    pnpm fetch
+
+# Default command can be overridden by docker compose
+CMD ["pnpm", "--filter", "@it-tms/web", "dev"]

--- a/apps/api/.air.toml
+++ b/apps/api/.air.toml
@@ -1,43 +1,20 @@
-  root = "."
-  testdata_dir = "testdata"
-  tmp_dir = "tmp"
+# Air configuration for local development hot reload
+root = "."
+tmp_dir = "tmp"
+testdata_dir = "testdata"
 
-  [build]
-    args_bin = []
-    bin = "./tmp/main"
-    cmd = "go build -o ./tmp/main ./cmd/server"
-    delay = 1000
-    exclude_dir = ["assets", "tmp", "vendor", "testdata", "uploads"]
-    exclude_file = []
-    exclude_regex = ["_test.go"]
-    exclude_unchanged = false
-    follow_symlink = false
-    full_bin = ""
-    include_dir = []
-    include_ext = ["go", "tpl", "tmpl", "html"]
-    include_file = []
-    kill_delay = "0s"
-    log = "build-errors.log"
-    poll = false
-    poll_interval = 0
-    rerun = false
-    rerun_delay = 500
-    send_interrupt = false
-    stop_on_root = false
+[build]
+  cmd = "go build -o ./tmp/main ./cmd/server"
+  bin = "./tmp/main"
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  exclude_dir = ["assets", "tmp", "uploads", "test_escape", "vendor"]
+  exclude_regex = ["_test\\.go"]
+  delay = 200
 
-  [color]
-    app = ""
-    build = "yellow"
-    main = "magenta"
-    runner = "green"
-    watcher = "cyan"
+[log]
+  time = true
 
-  [log]
-    main_only = false
-    time = false
-
-  [misc]
-    clean_on_exit = false
-  EOF
-  echo 'Starting development server with hot reload...';
-  air;
+[watch]
+  include = ["."]
+  include_ext = ["go", "sql", "yaml", "yml", "json", "tpl", "tmpl", "html"]
+  exclude_dir = ["assets", "tmp", "uploads", "test_escape", "vendor"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,153 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-it_tms}
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata-dev:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-it_tms}"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    networks:
+      - dev-network
+
+  db-migrate:
+    image: postgres:16-alpine
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-it_tms}
+      PGPASSWORD: ${POSTGRES_PASSWORD:-postgres}
+    volumes:
+      - ./db/migrations:/migrations:ro
+    command:
+      - sh
+      - -eu
+      - -c
+      - |
+        for migration in /migrations/*.up.sql; do
+          if [ -f "$${migration}" ]; then
+            echo "Applying $${migration}...";
+            psql -h db -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-it_tms} -f "$${migration}";
+          fi
+        done
+    networks:
+      - dev-network
+    restart: "no"
+
+  db-seed:
+    image: golang:1.23-alpine
+    depends_on:
+      db-migrate:
+        condition: service_completed_successfully
+    working_dir: /workspace/apps/api
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgres://postgres:postgres@db:5432/it_tms?sslmode=disable}
+      GO_ENV: development
+      GOMODCACHE: /go/pkg/mod
+      GOCACHE: /go-build
+    volumes:
+      - .:/workspace
+      - go-mod-cache:/go/pkg/mod
+      - go-build-cache:/go-build
+    command:
+      - sh
+      - -eu
+      - -c
+      - |
+        echo 'Seeding development database...';
+        go run cmd/seed/main.go;
+        echo 'Database ready.'
+    networks:
+      - dev-network
+    restart: "no"
+
+  api:
+    build:
+      context: ./apps/api
+      dockerfile: Dockerfile.dev
+    depends_on:
+      db-seed:
+        condition: service_completed_successfully
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgres://postgres:postgres@db:5432/it_tms?sslmode=disable}
+      PORT: 8080
+      JWT_SECRET: ${JWT_SECRET:-dev-secret-change-me-please-1234567890}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:3000}
+      WS_ALLOWED_ORIGINS: ${WS_ALLOWED_ORIGINS:-http://localhost:3000}
+      GO_ENV: development
+      SECURE_COOKIES: "false"
+      WEB_APP_URL: http://localhost:3000
+      UPLOAD_DIR: uploads
+    volumes:
+      - ./apps/api:/app
+      - go-mod-cache:/go/pkg/mod
+      - go-build-cache:/root/.cache/go-build
+      - api-uploads:/app/uploads
+    ports:
+      - "8080:8080"
+    command:
+      - sh
+      - -eu
+      - -c
+      - |
+        go install github.com/air-verse/air@v1.52.3;
+        air -c .air.toml
+    networks:
+      - dev-network
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    depends_on:
+      api:
+        condition: service_started
+    working_dir: /workspace
+    environment:
+      NODE_ENV: development
+      NEXT_TELEMETRY_DISABLED: 1
+      WATCHPACK_POLLING: "true"
+      CHOKIDAR_USEPOLLING: "true"
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8080}
+      NEXT_PUBLIC_WS_URL: ${NEXT_PUBLIC_WS_URL:-ws://localhost:8080/ws}
+      NEXT_PUBLIC_SOCKET_URL: ${NEXT_PUBLIC_SOCKET_URL:-ws://localhost:8080/ws}
+    volumes:
+      - .:/workspace
+      - web-node-modules:/workspace/node_modules
+      - web-app-node-modules:/workspace/apps/web/node_modules
+      - web-ui-node-modules:/workspace/packages/ui/node_modules
+      - pnpm-store:/root/.local/share/pnpm/store
+    ports:
+      - "3000:3000"
+    command:
+      - sh
+      - -eu
+      - -c
+      - |
+        pnpm install --frozen-lockfile --prefer-offline;
+        pnpm --filter @it-tms/web dev
+    networks:
+      - dev-network
+
+networks:
+  dev-network:
+    driver: bridge
+
+volumes:
+  pgdata-dev:
+  go-mod-cache:
+  go-build-cache:
+  api-uploads:
+  pnpm-store:
+  web-node-modules:
+  web-app-node-modules:
+  web-ui-node-modules:


### PR DESCRIPTION
## Summary
- add a docker-compose.dev.yml stack with Postgres, migrations, seeding, API hot reload, and Next.js dev server
- add a root Dockerfile.dev plus updated Air config to support fast local hot reloading for the Go API
- document the workflow in DEVELOPMENT.md and ignore generated tmp artifacts

## Testing
- pnpm install:check

------
https://chatgpt.com/codex/tasks/task_e_68d3e9b3de3c832e8da64c57669506c2