### PR TITLE
Remove alignment controls from markdown toolbar

### DIFF
--- a/apps/web/lib/tiptap-editor.tsx
+++ b/apps/web/lib/tiptap-editor.tsx
@@ -23,10 +23,6 @@ import {
   Redo,
   Eye,
   Edit3,
-  AlignLeft,
-  AlignCenter,
-  AlignRight,
-  AlignJustify
 } from 'lucide-react';
 import { Button } from '@heroui/react';
 
@@ -239,42 +235,6 @@ const Toolbar: React.FC<{ editor: any }> = ({ editor }) => {
           <Code2 className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
         </ToolbarButton>
       </ToolbarGroup>
-
-      <ToolbarSeparator />
-
-      {/* Alignment */}
-      <ToolbarGroup>
-        <ToolbarButton
-          onClick={() => editor.chain().focus().setTextAlign('left').run()}
-          isActive={editor.isActive({ textAlign: 'left' })}
-          title="Align Left"
-        >
-          <AlignLeft className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
-        </ToolbarButton>
-        <ToolbarButton
-          onClick={() => editor.chain().focus().setTextAlign('center').run()}
-          isActive={editor.isActive({ textAlign: 'center' })}
-          title="Align Center"
-        >
-          <AlignCenter className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
-        </ToolbarButton>
-        <ToolbarButton
-          onClick={() => editor.chain().focus().setTextAlign('right').run()}
-          isActive={editor.isActive({ textAlign: 'right' })}
-          title="Align Right"
-        >
-          <AlignRight className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
-        </ToolbarButton>
-        <ToolbarButton
-          onClick={() => editor.chain().focus().setTextAlign('justify').run()}
-          isActive={editor.isActive({ textAlign: 'justify' })}
-          title="Justify"
-        >
-          <AlignJustify className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
-        </ToolbarButton>
-      </ToolbarGroup>
-
-      <ToolbarSeparator />
 
       {/* Other */}
       <ToolbarGroup>


### PR DESCRIPTION
## Summary
- remove the text alignment buttons from the markdown editor toolbar so users cannot select left, center, right, or justify alignment

## Testing
- pnpm lint *(fails: existing ESLint parser errors across the @it-tms/web package)*

------
https://chatgpt.com/codex/tasks/task_e_68d408b5f030832ead78c23279a0eda8