### PR TITLE
Normalize ticket assessment defaults on edit

### DIFF
--- a/apps/web/app/[locale]/tickets/[id]/page.tsx
+++ b/apps/web/app/[locale]/tickets/[id]/page.tsx
@@ -210,59 +210,73 @@ export default function TicketDetails() {
         setStatus(j.data.ticket.status);
         // Initialize edit form with current ticket data
         const ticket = j.data.ticket;
-        
-        // Reconstruct priority input from stored data (if available) or use defaults
-        const hasRedFlags = ticket.redFlagsData && ticket.redFlagsData.criticalIssues && 
-          Object.values(ticket.redFlagsData.criticalIssues).some(v => v === true);
-        const hasImpact = ticket.impactAssessmentData && ticket.impactAssessmentData.impacts && 
-          Object.values(ticket.impactAssessmentData.impacts).some(v => v === true);
-        
-        const priorityInput: PriorityInput = {
-          redFlags: hasRedFlags ? ticket.redFlagsData.criticalIssues : {
-            outage: false,
-            paymentsFailing: false,
-            securityBreach: false,
-            nonCompliance: false
-          },
-          impact: hasImpact ? ticket.impactAssessmentData.impacts : {
-            lostRevenue: false,
-            coreProcesses: false,
-            dataLoss: false
-          },
-          urgency: (ticket.urgencyTimelineData && ticket.urgencyTimelineData.timeline) ? ticket.urgencyTimelineData.timeline : "none"
+
+        const toBoolean = (value: unknown) => {
+          if (typeof value === "boolean") return value;
+          if (typeof value === "number") return value === 1;
+          if (typeof value === "string") {
+            const normalized = value.trim().toLowerCase();
+            return normalized === "true" || normalized === "1" || normalized === "yes" || normalized === "on";
+          }
+          return false;
         };
-        
+
+        const redFlagSource = ticket.redFlagsData?.criticalIssues ?? {};
+        const impactSource = ticket.impactAssessmentData?.impacts ?? {};
+
+        const priorityInput: PriorityInput = {
+          redFlags: {
+            outage: toBoolean(redFlagSource.outage),
+            paymentsFailing: toBoolean(redFlagSource.paymentsFailing),
+            securityBreach: toBoolean(redFlagSource.securityBreach),
+            nonCompliance: toBoolean(redFlagSource.nonCompliance),
+          },
+          impact: {
+            lostRevenue: toBoolean(impactSource.lostRevenue),
+            coreProcesses: toBoolean(impactSource.coreProcesses),
+            dataLoss: toBoolean(impactSource.dataLoss),
+          },
+          urgency:
+            (typeof ticket.urgencyTimelineData?.timeline === "string"
+              ? (ticket.urgencyTimelineData.timeline as PriorityInput["urgency"])
+              : undefined) || "none",
+        };
+
+        const hasEffortData =
+          ticket.effortData &&
+          typeof ticket.effortData === "object" &&
+          Object.keys(ticket.effortData).length > 0;
+
+        const effortData = (hasEffortData ? ticket.effortData : {}) as any;
+
+        const effort = {
+          development: {
+            versionControl: toBoolean(effortData?.development?.versionControl),
+            externalService: toBoolean(effortData?.development?.externalService),
+            internalIntegration: toBoolean(effortData?.development?.internalIntegration),
+          },
+          security: {
+            legalCompliance: toBoolean(effortData?.security?.legalCompliance),
+            accessControl: toBoolean(effortData?.security?.accessControl),
+            personalData: toBoolean(effortData?.security?.personalData),
+          },
+          data: {
+            migration: toBoolean(effortData?.data?.migration),
+            dataPreparation: toBoolean(effortData?.data?.dataPreparation),
+            encryption: toBoolean(effortData?.data?.encryption),
+          },
+          operations: {
+            offHours: toBoolean(effortData?.operations?.offHours),
+            training: toBoolean(effortData?.operations?.training),
+            uat: toBoolean(effortData?.operations?.uat),
+          },
+        };
+
         const newEditForm = {
           initialType: ticket.initialType || "",
           resolvedType: ticket.resolvedType || "",
           priorityInput,
-          effort: (ticket.effortData && ticket.effortData !== null && 
-            typeof ticket.effortData === 'object' && Object.keys(ticket.effortData).length > 0 && 
-            Object.values(ticket.effortData).some(section => 
-              typeof section === 'object' && section !== null && 
-              Object.values(section).some(v => v === true)
-            )) ? ticket.effortData : { 
-            development: {
-              versionControl: false,
-              externalService: false,
-              internalIntegration: false
-            }, 
-            security: {
-              legalCompliance: false,
-              accessControl: false,
-              personalData: false
-            }, 
-            data: {
-              migration: false,
-              dataPreparation: false,
-              encryption: false
-            }, 
-            operations: {
-              offHours: false,
-              training: false,
-              uat: false
-            }
-          }
+          effort,
         };
         setEditForm(newEditForm);
         // Initialize content edit form
@@ -279,33 +293,7 @@ export default function TicketDetails() {
           resolvedType: ticket.resolvedType || "",
           priority: ticket.priority || "",
           priorityInput: priorityInput,
-          effort: (ticket.effortData && ticket.effortData !== null && 
-            typeof ticket.effortData === 'object' && Object.keys(ticket.effortData).length > 0 && 
-            Object.values(ticket.effortData).some(section => 
-              typeof section === 'object' && section !== null && 
-              Object.values(section).some(v => v === true)
-            )) ? ticket.effortData : { 
-            development: {
-              versionControl: false,
-              externalService: false,
-              internalIntegration: false
-            }, 
-            security: {
-              legalCompliance: false,
-              accessControl: false,
-              personalData: false
-            }, 
-            data: {
-              migration: false,
-              dataPreparation: false,
-              encryption: false
-            }, 
-            operations: {
-              offHours: false,
-              training: false,
-              uat: false
-            }
-          }
+          effort,
         });
       })
       .finally(() => setLoading(false));


### PR DESCRIPTION
## Summary
- normalize stored priority and effort checklist data when loading ticket details
- ensure edit forms receive boolean values so defaults appear without an extra save

## Testing
- pnpm --filter @it-tms/web lint *(fails: existing parsing errors in eslint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d2307bfc832e9eb0192f00f0bdb3