### PR TITLE
Allow classifying issue reports in any status

### DIFF
--- a/apps/web/app/[locale]/admin/classify/classification-utils.test.ts
+++ b/apps/web/app/[locale]/admin/classify/classification-utils.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+  filterClassifiableIssueReports,
+  isClassifiableIssueReport,
+  type ClassificationTicket,
+} from './classification-utils';
+
+type PartialTicket = Partial<ClassificationTicket> & Pick<ClassificationTicket, 'id' | 'code'>;
+
+const buildTicket = (overrides: PartialTicket): ClassificationTicket => ({
+  id: overrides.id,
+  code: overrides.code,
+  title: overrides.title ?? 'Sample',
+  description: overrides.description ?? 'Sample description',
+  initialType: overrides.initialType ?? 'ISSUE_REPORT',
+  resolvedType: overrides.resolvedType ?? null,
+  status: overrides.status ?? 'PENDING',
+  priority: overrides.priority ?? 'P1',
+  impactScore: overrides.impactScore ?? 0,
+  urgencyScore: overrides.urgencyScore ?? 0,
+  finalScore: overrides.finalScore ?? 0,
+  redFlag: overrides.redFlag ?? false,
+  effortData: overrides.effortData,
+  effortScore: overrides.effortScore ?? 0,
+  createdBy: overrides.createdBy,
+  latestComment: overrides.latestComment,
+  createdAt: overrides.createdAt ?? new Date().toISOString(),
+  updatedAt: overrides.updatedAt ?? new Date().toISOString(),
+});
+
+describe('classification utils', () => {
+  it('marks issue reports without classification as classifiable regardless of status', () => {
+    const pending = buildTicket({ id: '1', code: 1, status: 'PENDING' });
+    const resolved = buildTicket({ id: '2', code: 2, status: 'RESOLVED' });
+
+    expect(isClassifiableIssueReport(pending)).toBe(true);
+    expect(isClassifiableIssueReport(resolved)).toBe(true);
+  });
+
+  it('excludes tickets that already have a resolved classification', () => {
+    const dataCorrection = buildTicket({ id: '3', code: 3, resolvedType: 'DATA_CORRECTION' });
+    const emergencyChange = buildTicket({ id: '4', code: 4, resolvedType: 'EMERGENCY_CHANGE' });
+
+    expect(isClassifiableIssueReport(dataCorrection)).toBe(false);
+    expect(isClassifiableIssueReport(emergencyChange)).toBe(false);
+  });
+
+  it('treats empty resolved type strings as unclassified', () => {
+    const emptyResolved = buildTicket({ id: '5', code: 5, resolvedType: '' });
+
+    expect(isClassifiableIssueReport(emptyResolved)).toBe(true);
+  });
+
+  it('filters only classifiable issue reports from a list', () => {
+    const tickets = [
+      buildTicket({ id: '6', code: 6 }),
+      buildTicket({ id: '7', code: 7, resolvedType: 'DATA_CORRECTION' }),
+      buildTicket({ id: '8', code: 8, initialType: 'SERVICE_REQUEST' }),
+      buildTicket({ id: '9', code: 9, resolvedType: null, status: 'IN_PROGRESS' }),
+    ];
+
+    const filtered = filterClassifiableIssueReports(tickets);
+
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((ticket) => ticket.id)).toEqual(['6', '9']);
+  });
+});

--- a/apps/web/app/[locale]/admin/classify/classification-utils.ts
+++ b/apps/web/app/[locale]/admin/classify/classification-utils.ts
@@ -1,0 +1,38 @@
+export type ClassificationTicket = {
+  id: string;
+  code: number;
+  title: string;
+  description: string;
+  initialType: string;
+  resolvedType?: string | null;
+  status: string;
+  priority: string;
+  impactScore: number;
+  urgencyScore: number;
+  finalScore: number;
+  redFlag: boolean;
+  effortData?: any;
+  effortScore?: number;
+  createdBy?: string;
+  latestComment?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const ISSUE_REPORT_TYPE = "ISSUE_REPORT";
+
+const hasResolvedClassification = (resolvedType?: string | null) => {
+  if (!resolvedType) {
+    return false;
+  }
+
+  return resolvedType.trim().length > 0;
+};
+
+export const isClassifiableIssueReport = (ticket: ClassificationTicket): boolean => {
+  return ticket.initialType === ISSUE_REPORT_TYPE && !hasResolvedClassification(ticket.resolvedType);
+};
+
+export const filterClassifiableIssueReports = (
+  tickets: ClassificationTicket[],
+): ClassificationTicket[] => tickets.filter(isClassifiableIssueReport);

--- a/apps/web/app/[locale]/admin/classify/page.tsx
+++ b/apps/web/app/[locale]/admin/classify/page.tsx
@@ -5,31 +5,15 @@ import { Tags, CheckCircle, Info, Eye, Calendar, User, Phone, Mail, AlertTriangl
 import { useTranslations } from 'next-intl';
 import { MarkdownRenderer } from '@/lib/markdown-renderer';
 import { convertContentToMarkdown } from '@/lib/html-to-markdown';
+import {
+  filterClassifiableIssueReports,
+  type ClassificationTicket as Ticket,
+} from './classification-utils';
 
 // Use current hostname with port 8000 for production-like environment
 const API = typeof window !== 'undefined' && window.location.port === '8000'
   ? '' // Use relative URLs when accessed through port 8000 (production-like)
   : (process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080");
-
-type Ticket = { 
-  id: string; 
-  code: number;
-  title: string; 
-  description: string;
-  initialType: string; 
-  resolvedType?: string | null;
-  priority: string;
-  impactScore: number;
-  urgencyScore: number;
-  finalScore: number;
-  redFlag: boolean;
-  effortData?: any;
-  effortScore?: number;
-  createdBy?: string;
-  latestComment?: string;
-  createdAt: string;
-  updatedAt: string;
-};
 
 export default function ClassifyPage() {
   const t = useTranslations('admin');
@@ -69,9 +53,12 @@ export default function ClassifyPage() {
 
   function load() {
     setLoading(true);
-    fetch(`${API}/api/v1/tickets?status=pending`, { credentials: "include" })
+    fetch(`${API}/api/v1/tickets?pageSize=100`, { credentials: "include" })
       .then((r) => r.json())
-      .then((j) => setItems(j.data.filter((t: Ticket) => t.initialType === "ISSUE_REPORT" && !t.resolvedType)))
+      .then((j) => {
+        const tickets = Array.isArray(j.data) ? j.data : [];
+        setItems(filterClassifiableIssueReports(tickets));
+      })
       .finally(() => setLoading(false));
   }
   useEffect(() => { load(); }, []);

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,1 +1,1 @@
-import "@testing-library/jest-dom";
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Summary
- update the classification page to load unclassified issue reports regardless of ticket status
- add reusable helpers for identifying classifiable issue reports and cover them with unit tests
- adjust the Vitest setup to use the vitest-compatible Jest DOM integration

## Testing
- pnpm --filter @it-tms/web test

------
https://chatgpt.com/codex/tasks/task_e_68d4d36e0228832eb8f70bff442414de