### PR TITLE
Add loading state when posting ticket comments

### DIFF
--- a/apps/web/app/[locale]/tickets/[id]/page.tsx
+++ b/apps/web/app/[locale]/tickets/[id]/page.tsx
@@ -63,6 +63,7 @@ export default function TicketDetails() {
   });
   const [comment, setComment] = useState("");
   const [commentFiles, setCommentFiles] = useState<File[]>([]);
+  const [commentPosting, setCommentPosting] = useState(false);
   const [status, setStatus] = useState("");
   const [loading, setLoading] = useState(true);
   const [commentsLoading, setCommentsLoading] = useState(false);
@@ -433,12 +434,13 @@ export default function TicketDetails() {
   }
 
   async function postComment() {
-    if (!comment.trim()) return;
-    
+    if (!comment.trim() || commentPosting) return;
+
+    setCommentPosting(true);
     try {
       // Create comment first
       const res = await fetch(`${API}/api/v1/tickets/${id}/comments`, {
-        method: "POST", 
+        method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ body: comment }),
@@ -448,7 +450,7 @@ export default function TicketDetails() {
         alert("Failed to post comment");
         return;
       }
-      
+
       // Always consume the response to get the comment ID
       const response = await res.json();
       
@@ -479,6 +481,8 @@ export default function TicketDetails() {
       loadComments(1); // Reload comments to show the new one
     } catch (error) {
       alert("Failed to post comment");
+    } finally {
+      setCommentPosting(false);
     }
   }
 
@@ -867,10 +871,11 @@ export default function TicketDetails() {
                         </div>
                       )}
                     </div>
-                    <Button 
-                      color="primary" 
+                    <Button
+                      color="primary"
                       onPress={postComment}
-                      isDisabled={!comment.trim()}
+                      isDisabled={!comment.trim() || commentPosting}
+                      isLoading={commentPosting}
                       className="w-full"
                     >
                       {t('postComment')}


### PR DESCRIPTION
## Summary
- add a dedicated loading flag for ticket comment submissions
- prevent duplicate comment requests by disabling and showing a loading state on the post button

## Testing
- pnpm --filter @it-tms/web lint *(fails: eslint parser errors present in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d847e2fc832ea4a5892baecb923b