### PR TITLE
feat: improve unauthorized permission notifications

### DIFF
--- a/apps/web/app/[locale]/admin/classify/page.tsx
+++ b/apps/web/app/[locale]/admin/classify/page.tsx
@@ -5,6 +5,7 @@ import { Tags, CheckCircle, Info, Eye, Calendar, User, Phone, Mail, AlertTriangl
 import { useTranslations } from 'next-intl';
 import { MarkdownRenderer } from '@/lib/markdown-renderer';
 import { convertContentToMarkdown } from '@/lib/html-to-markdown';
+import { usePermissionAwareFetch } from '@/hooks/usePermissionAwareFetch';
 
 // Use current hostname with port 8000 for production-like environment
 const API = typeof window !== 'undefined' && window.location.port === '8000'
@@ -39,6 +40,7 @@ export default function ClassifyPage() {
   const [loading, setLoading] = useState(true);
   const [selectedTicket, setSelectedTicket] = useState<Ticket | null>(null);
   const {isOpen, onOpen, onClose} = useDisclosure();
+  const permissionedFetch = usePermissionAwareFetch();
 
   // Debug function to log selection changes
   const handleSelectionChange = (ticketId: string, keys: any) => {
@@ -87,12 +89,26 @@ export default function ClassifyPage() {
       payload = { resolvedType: rt };
     }
     
-    await fetch(`${API}/api/v1/tickets/${id}/classify`, {
-      method: "POST",
-      credentials: "include",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    });
+    const response = await permissionedFetch(
+      `${API}/api/v1/tickets/${id}/classify`,
+      {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      },
+      { feature: "classify tickets" }
+    );
+
+    if (!response) {
+      return;
+    }
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => null);
+      console.error("Failed to classify ticket:", errorData?.error?.message || response.statusText);
+      return;
+    }
     load();
   }
 

--- a/apps/web/app/[locale]/layout.tsx
+++ b/apps/web/app/[locale]/layout.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from 'react';
 import { HeroUIProvider } from "@heroui/react";
 import { AuthProvider } from "../../lib/auth";
 import { NotificationProvider } from "../../lib/notifications";
+import { UnauthorizedModalProvider } from "../../lib/unauthorized-modal";
 import { Navigation } from "../../components/Navigation";
 import { NotificationToast } from "../../components/NotificationToast";
 import { locales } from "../../i18n";
@@ -47,18 +48,20 @@ export default async function LocaleLayout({
     <NextIntlClientProvider messages={messages} locale={locale}>
       <HeroUIProvider>
         <AuthProvider>
-          <NotificationProvider>
-            <div 
-              className={locale === 'th' ? ibmPlexSansThai.className : undefined}
-              lang={locale}
-            >
-              <header className="sticky top-0 z-50 glass border-b border-white/10">
-                <Navigation />
-              </header>
-              <main className="min-h-screen pt-6 pb-6">{children}</main>
-              <NotificationToast />
-            </div>
-          </NotificationProvider>
+          <UnauthorizedModalProvider>
+            <NotificationProvider>
+              <div
+                className={locale === 'th' ? ibmPlexSansThai.className : undefined}
+                lang={locale}
+              >
+                <header className="sticky top-0 z-50 glass border-b border-white/10">
+                  <Navigation />
+                </header>
+                <main className="min-h-screen pt-6 pb-6">{children}</main>
+                <NotificationToast />
+              </div>
+            </NotificationProvider>
+          </UnauthorizedModalProvider>
         </AuthProvider>
       </HeroUIProvider>
     </NextIntlClientProvider>

--- a/apps/web/app/[locale]/profile/page.tsx
+++ b/apps/web/app/[locale]/profile/page.tsx
@@ -7,6 +7,7 @@ import { Card, CardBody, CardHeader, Input, Button, Avatar, Progress } from "@he
 import { useAuth } from "@/lib/auth";
 import { AlertTriangle, Camera, User, BarChart3, TrendingUp } from "lucide-react";
 import { useTranslations } from 'next-intl';
+import { usePermissionAwareFetch } from '@/hooks/usePermissionAwareFetch';
 
 // Use current hostname with port 8000 for production-like environment
 const API = typeof window !== 'undefined' && window.location.port === '8000'
@@ -44,6 +45,7 @@ export default function ProfilePage() {
   const t = useTranslations('profile');
   const tCommon = useTranslations('common');
   const { user, isLoading, refreshUser } = useAuth();
+  const permissionedFetch = usePermissionAwareFetch();
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [performanceStats, setPerformanceStats] = useState<PerformanceStats | null>(null);
   const [isUploading, setIsUploading] = useState(false);
@@ -107,14 +109,28 @@ export default function ProfilePage() {
     setUpdateSuccess(null);
     
     try {
-      const response = await fetch(`${API}/api/v1/profile`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
+      const response = await permissionedFetch(
+        `${API}/api/v1/profile`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          credentials: "include",
+          body: JSON.stringify(data),
         },
-        credentials: "include",
-        body: JSON.stringify(data),
-      });
+        {
+          feature: "update profile information",
+          hideSignInCta: Boolean(user),
+          message: user
+            ? "Your current role does not allow profile updates. Please contact your administrator to request access."
+            : undefined,
+        }
+      );
+
+      if (!response) {
+        return;
+      }
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => null);
@@ -160,14 +176,28 @@ export default function ProfilePage() {
 
       console.log('Uploading profile picture:', file.name, file.type, file.size);
 
-      const response = await fetch(`${API}/api/v1/profile/picture`, {
-        method: "POST",
-        credentials: "include",
-        body: formData,
-      });
+      const response = await permissionedFetch(
+        `${API}/api/v1/profile/picture`,
+        {
+          method: "POST",
+          credentials: "include",
+          body: formData,
+        },
+        {
+          feature: "upload a profile picture",
+          hideSignInCta: Boolean(user),
+          message: user
+            ? "You don't have permission to update the profile picture for this account."
+            : undefined,
+        }
+      );
+
+      if (!response) {
+        return;
+      }
 
       const result = await response.json();
-      
+
       if (!response.ok) {
         const errorMessage = result?.error?.message || 'Failed to upload profile picture';
         console.error('Upload failed:', result);

--- a/apps/web/app/[locale]/tickets/[id]/page.tsx
+++ b/apps/web/app/[locale]/tickets/[id]/page.tsx
@@ -11,6 +11,7 @@ import UserSearchSelect from "@/components/UserSearchSelect";
 import EffortAssessmentExplanation from "@/components/EffortAssessmentExplanation";
 import TicketCompletionCelebration from "@/components/TicketCompletionCelebration";
 import { useTranslations, useLocale } from 'next-intl';
+import { usePermissionAwareFetch } from '@/hooks/usePermissionAwareFetch';
 import { 
   AlertTriangle, 
   Paperclip, 
@@ -51,6 +52,7 @@ export default function TicketDetails() {
   const params = useParams<{ id: string }>();
   const id = params.id;
   const { user, canEditTicket, canCancelTicket, canAssignTicket, canModifyTicketFields, canEditTicketContent } = useAuth();
+  const permissionedFetch = usePermissionAwareFetch();
   const [data, setData] = useState<any>(null);
   const [comments, setComments] = useState<any[]>([]);
   const [commentPagination, setCommentPagination] = useState({
@@ -69,6 +71,7 @@ export default function TicketDetails() {
   const [statusLoading, setStatusLoading] = useState(false);
   const [statusError, setStatusError] = useState("");
   const [showCelebration, setShowCelebration] = useState(false);
+  const [downloadingAttachmentId, setDownloadingAttachmentId] = useState<string | null>(null);
   
   // Ticket editing state
   const [isEditing, setIsEditing] = useState(false);
@@ -362,13 +365,27 @@ export default function TicketDetails() {
       ].filter(Boolean).length;
       payload.effortScore = effortBase;
       
-      const response = await fetch(`${API}/api/v1/tickets/${id}/fields`, {
-        method: "PATCH",
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-      
+      const response = await permissionedFetch(
+        `${API}/api/v1/tickets/${id}/fields`,
+        {
+          method: "PATCH",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        },
+        {
+          feature: "edit ticket fields",
+          hideSignInCta: Boolean(user),
+          message: user
+            ? "You don't have the required role to modify this ticket's workflow fields."
+            : undefined,
+        }
+      );
+
+      if (!response) {
+        return;
+      }
+
       if (!response.ok) {
         const errorData = await response.json();
         throw new Error(errorData.error?.message || "Failed to update ticket fields");
@@ -408,13 +425,27 @@ export default function TicketDetails() {
         return;
       }
       
-      const response = await fetch(`${API}/api/v1/tickets/${id}`, {
-        method: "PATCH",
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-      
+      const response = await permissionedFetch(
+        `${API}/api/v1/tickets/${id}`,
+        {
+          method: "PATCH",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        },
+        {
+          feature: "edit ticket content",
+          hideSignInCta: Boolean(user),
+          message: user
+            ? "You don't have permission to update this ticket's title or description."
+            : undefined,
+        }
+      );
+
+      if (!response) {
+        return;
+      }
+
       if (!response.ok) {
         const errorData = await response.json();
         throw new Error(errorData.error?.message || "Failed to update ticket content");
@@ -437,18 +468,32 @@ export default function TicketDetails() {
     
     try {
       // Create comment first
-      const res = await fetch(`${API}/api/v1/tickets/${id}/comments`, {
-        method: "POST", 
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ body: comment }),
-      });
-      
+      const res = await permissionedFetch(
+        `${API}/api/v1/tickets/${id}/comments`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ body: comment }),
+        },
+        {
+          feature: "post comments",
+          hideSignInCta: Boolean(user),
+          message: user
+            ? "You don't have permission to add comments to this ticket."
+            : undefined,
+        }
+      );
+
+      if (!res) {
+        return;
+      }
+
       if (!res.ok) {
         alert("Failed to post comment");
         return;
       }
-      
+
       // Always consume the response to get the comment ID
       const response = await res.json();
       
@@ -461,12 +506,23 @@ export default function TicketDetails() {
           formData.append('files', file);
         });
         
-        const uploadRes = await fetch(`${API}/api/v1/tickets/${id}/comments/${commentId}/attachments`, {
-          method: "POST",
-          credentials: "include",
-          body: formData,
-        });
-        
+        const uploadRes = await permissionedFetch(
+          `${API}/api/v1/tickets/${id}/comments/${commentId}/attachments`,
+          {
+            method: "POST",
+            credentials: "include",
+            body: formData,
+          },
+          {
+            feature: "upload comment attachments",
+            hideSignInCta: Boolean(user),
+          }
+        );
+
+        if (!uploadRes) {
+          return;
+        }
+
         if (!uploadRes.ok) {
           const errorData = await uploadRes.text();
           alert("Comment posted successfully, but some attachments failed to upload. Please try adding them again.");
@@ -484,18 +540,32 @@ export default function TicketDetails() {
 
   async function changeStatus() {
     if (!status.trim()) return;
-    
+
     setStatusLoading(true);
     setStatusError("");
     
     try {
-      const response = await fetch(`${API}/api/v1/tickets/${id}/status`, {
-        method: "POST", 
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status }),
-      });
-      
+      const response = await permissionedFetch(
+        `${API}/api/v1/tickets/${id}/status`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status }),
+        },
+        {
+          feature: "update ticket status",
+          hideSignInCta: Boolean(user),
+          message: user
+            ? "You don't have permission to transition this ticket to a new status."
+            : undefined,
+        }
+      );
+
+      if (!response) {
+        return;
+      }
+
       if (!response.ok) {
         const errorData = await response.json();
         throw new Error(errorData.error?.message || "Failed to update status");
@@ -515,6 +585,65 @@ export default function TicketDetails() {
       setStatusError(error instanceof Error ? error.message : "Failed to update status");
     } finally {
       setStatusLoading(false);
+    }
+  }
+
+  async function handleAttachmentDownload(url: string, fallbackName: string, attachmentId: string, featureDescription: string) {
+    setDownloadingAttachmentId(attachmentId);
+
+    try {
+      const hideSignInCta = Boolean(user && user.role !== "Anonymous");
+      const response = await permissionedFetch(
+        url,
+        { credentials: "include" },
+        {
+          feature: featureDescription,
+          hideSignInCta,
+          primaryActionLabel: "Sign in to download",
+          message: hideSignInCta
+            ? "You don't have permission to download attachments for this ticket. Please contact your administrator if you need access."
+            : undefined,
+        }
+      );
+
+      if (!response) {
+        return;
+      }
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => null);
+        throw new Error(errorText || "Failed to download attachment");
+      }
+
+      const blob = await response.blob();
+      let downloadName = fallbackName;
+      const disposition = response.headers.get("Content-Disposition");
+      if (disposition) {
+        const utf8Match = disposition.match(/filename\*=UTF-8''([^;]+)/i);
+        const asciiMatch = disposition.match(/filename="?([^";]+)"?/i);
+        const rawName = utf8Match?.[1] || asciiMatch?.[1];
+        if (rawName) {
+          try {
+            downloadName = decodeURIComponent(rawName);
+          } catch {
+            downloadName = rawName;
+          }
+        }
+      }
+
+      const downloadUrl = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = downloadUrl;
+      link.download = downloadName;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(downloadUrl);
+    } catch (error) {
+      console.error("Failed to download attachment:", error);
+      alert("We couldn't download this attachment. Please try again or contact support if the issue persists.");
+    } finally {
+      setDownloadingAttachmentId(null);
     }
   }
 
@@ -669,15 +798,19 @@ export default function TicketDetails() {
                     </h3>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                   {data.attachments.map((att: any) => (
-                    <a
+                    <button
                       key={att.id}
-                      href={`${API}/api/v1/attachments/${att.id}/download`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center gap-3 p-3 bg-white/5 hover:bg-white/10 rounded-lg transition-colors group"
+                      type="button"
+                      onClick={() => handleAttachmentDownload(`${API}/api/v1/attachments/${att.id}/download`, att.filename, att.id, 'download attachments')}
+                      className="flex items-center gap-3 p-3 bg-white/5 hover:bg-white/10 rounded-lg transition-colors group text-left"
+                      disabled={downloadingAttachmentId === att.id}
                     >
                       <div className="flex-shrink-0">
-                        <Paperclip size={20} className="text-primary-400 group-hover:text-primary-300" />
+                        {downloadingAttachmentId === att.id ? (
+                          <div className="w-5 h-5 border-2 border-primary-400/70 border-t-transparent rounded-full animate-spin" />
+                        ) : (
+                          <Paperclip size={20} className="text-primary-400 group-hover:text-primary-300" />
+                        )}
                       </div>
                       <div className="flex-1 min-w-0">
                         <p className="font-medium text-white/90 truncate">{att.filename}</p>
@@ -688,7 +821,7 @@ export default function TicketDetails() {
                           )}
                         </p>
                       </div>
-                    </a>
+                    </button>
                   ))}
                 </div>
               </div>
@@ -918,17 +1051,21 @@ export default function TicketDetails() {
                             <h4 className="text-xs font-medium text-white/60">{t('attachmentsColon')}</h4>
                             <div className="flex flex-wrap gap-2">
                               {c.attachments.map((att: any) => (
-                                <a
+                                <button
                                   key={att.id}
-                                  href={`${API}/api/v1/comment-attachments/${att.id}/download`}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="flex items-center gap-2 px-3 py-2 bg-white/10 hover:bg-white/20 rounded-lg text-xs transition-colors"
+                                  type="button"
+                                  onClick={() => handleAttachmentDownload(`${API}/api/v1/comment-attachments/${att.id}/download`, att.filename, att.id, 'download comment attachments')}
+                                  className="flex items-center gap-2 px-3 py-2 bg-white/10 hover:bg-white/20 rounded-lg text-xs transition-colors text-left"
+                                  disabled={downloadingAttachmentId === att.id}
                                 >
-                                  <Paperclip size={14} />
+                                  {downloadingAttachmentId === att.id ? (
+                                    <div className="w-4 h-4 border-2 border-primary-300/80 border-t-transparent rounded-full animate-spin" />
+                                  ) : (
+                                    <Paperclip size={14} />
+                                  )}
                                   <span>{att.filename}</span>
                                   <span className="text-white/60">({(att.size / 1024 / 1024).toFixed(2)} MB)</span>
-                                </a>
+                                </button>
                               ))}
                             </div>
                           </div>
@@ -1105,12 +1242,29 @@ export default function TicketDetails() {
                               color="danger"
                               variant="light"
                               onPress={async () => {
-                                await fetch(`${API}/api/v1/tickets/${id}/assign`, {
-                                  method: "DELETE",
-                                  credentials: "include",
-                                  headers: { "Content-Type": "application/json" },
-                                  body: JSON.stringify({ assigneeIds: [assignee.id] }),
-                                });
+                                const response = await permissionedFetch(
+                                  `${API}/api/v1/tickets/${id}/assign`,
+                                  {
+                                    method: "DELETE",
+                                    credentials: "include",
+                                    headers: { "Content-Type": "application/json" },
+                                    body: JSON.stringify({ assigneeIds: [assignee.id] }),
+                                  },
+                                  {
+                                    feature: "update ticket assignments",
+                                    hideSignInCta: Boolean(user),
+                                  }
+                                );
+
+                                if (!response) {
+                                  return;
+                                }
+
+                                if (!response.ok) {
+                                  const errorData = await response.json().catch(() => null);
+                                  console.error("Failed to unassign user:", errorData?.error?.message || response.statusText);
+                                  return;
+                                }
                                 load();
                                 // Reload comments with retry mechanism to ensure auto-comment is visible
                                 loadCommentsWithRetry(1);
@@ -1127,16 +1281,33 @@ export default function TicketDetails() {
                 )}
 
                 {/* Quick Self-Assign */}
-                <Button 
-                  color="secondary" 
+                <Button
+                  color="secondary"
                   variant="flat"
                   onPress={async () => {
-                    await fetch(`${API}/api/v1/tickets/${id}/assign`, {
-                      method: "POST",
-                      credentials: "include",
-                      headers: { "Content-Type": "application/json" },
-                      body: JSON.stringify({ self: true }),
-                    });
+                    const response = await permissionedFetch(
+                      `${API}/api/v1/tickets/${id}/assign`,
+                      {
+                        method: "POST",
+                        credentials: "include",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({ self: true }),
+                      },
+                      {
+                        feature: "assign yourself to the ticket",
+                        hideSignInCta: Boolean(user),
+                      }
+                    );
+
+                    if (!response) {
+                      return;
+                    }
+
+                    if (!response.ok) {
+                      const errorData = await response.json().catch(() => null);
+                      console.error("Failed to assign ticket to current user:", errorData?.error?.message || response.statusText);
+                      return;
+                    }
                     load();
                     // Reload comments with retry mechanism to ensure auto-comment is visible
                     loadCommentsWithRetry(1);
@@ -1160,12 +1331,29 @@ export default function TicketDetails() {
                       color="primary"
                       onPress={async () => {
                         if (selectedAssignees.length > 0) {
-                          await fetch(`${API}/api/v1/tickets/${id}/assign`, {
-                            method: "POST",
-                            credentials: "include",
-                            headers: { "Content-Type": "application/json" },
-                            body: JSON.stringify({ assigneeIds: selectedAssignees }),
-                          });
+                          const response = await permissionedFetch(
+                            `${API}/api/v1/tickets/${id}/assign`,
+                            {
+                              method: "POST",
+                              credentials: "include",
+                              headers: { "Content-Type": "application/json" },
+                              body: JSON.stringify({ assigneeIds: selectedAssignees }),
+                            },
+                            {
+                              feature: "assign ticket collaborators",
+                              hideSignInCta: Boolean(user),
+                            }
+                          );
+
+                          if (!response) {
+                            return;
+                          }
+
+                          if (!response.ok) {
+                            const errorData = await response.json().catch(() => null);
+                            console.error("Failed to assign selected users:", errorData?.error?.message || response.statusText);
+                            return;
+                          }
                           setSelectedAssignees([]);
                           load();
                           // Reload comments with retry mechanism to ensure auto-comment is visible
@@ -1194,16 +1382,33 @@ export default function TicketDetails() {
                 </h3>
               </CardHeader>
               <CardBody>
-                <Button 
-                  color="secondary" 
+                <Button
+                  color="secondary"
                   variant="flat"
                   onPress={async () => {
-                    await fetch(`${API}/api/v1/tickets/${id}/assign`, {
-                      method: "POST",
-                      credentials: "include",
-                      headers: { "Content-Type": "application/json" },
-                      body: JSON.stringify({ self: true }),
-                    });
+                    const response = await permissionedFetch(
+                      `${API}/api/v1/tickets/${id}/assign`,
+                      {
+                        method: "POST",
+                        credentials: "include",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({ self: true }),
+                      },
+                      {
+                        feature: "assign yourself to the ticket",
+                        hideSignInCta: Boolean(user),
+                      }
+                    );
+
+                    if (!response) {
+                      return;
+                    }
+
+                    if (!response.ok) {
+                      const errorData = await response.json().catch(() => null);
+                      console.error("Failed to self-assign ticket:", errorData?.error?.message || response.statusText);
+                      return;
+                    }
                     load();
                     // Reload comments with retry mechanism to ensure auto-comment is visible
                     loadCommentsWithRetry(1);

--- a/apps/web/app/[locale]/tickets/new/page.tsx
+++ b/apps/web/app/[locale]/tickets/new/page.tsx
@@ -4,6 +4,7 @@ import { Button, Card, CardBody, CardHeader, Input, Textarea, Checkbox } from "@
 import { computePriority, PriorityInput } from "@/lib/priority";
 import { TiptapEditor } from "@/lib/tiptap-editor";
 import { useAuth } from "@/lib/auth";
+import { usePermissionAwareFetch } from '@/hooks/usePermissionAwareFetch';
 import { useLocale, useTranslations } from 'next-intl';
 import { 
   AlertTriangle, 
@@ -65,6 +66,7 @@ export default function NewTicket() {
   const [draft, setDraft] = useState<Draft>(initialDraft);
   const [submitting, setSubmitting] = useState(false);
   const { user, isLoading, canCreateTicketType } = useAuth();
+  const permissionedFetch = usePermissionAwareFetch();
 
   // Show loading state while checking authentication
   if (isLoading) {
@@ -157,13 +159,28 @@ export default function NewTicket() {
       };
       
       // Create ticket first
-      const res = await fetch(`${API}/api/v1/tickets`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify(payload),
-      });
-      
+      const res = await permissionedFetch(
+        `${API}/api/v1/tickets`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify(payload),
+        },
+        {
+          feature: "create a new ticket",
+          hideSignInCta: Boolean(user && user.role !== "Anonymous"),
+          message: user && user.role !== "Anonymous"
+            ? "Your current role does not allow creating this type of ticket. Please contact your supervisor for assistance."
+            : undefined,
+        }
+      );
+
+      if (!res) {
+        setSubmitting(false);
+        return;
+      }
+
       if (!res.ok) {
         const errorData = await res.text();
         console.error("Failed to create ticket:", errorData);
@@ -171,7 +188,7 @@ export default function NewTicket() {
         setSubmitting(false);
         return;
       }
-      
+
       const { data } = await res.json();
       const ticketId = data.id;
       
@@ -182,12 +199,24 @@ export default function NewTicket() {
           formData.append('files', file);
         });
         
-        const uploadRes = await fetch(`${API}/api/v1/tickets/${ticketId}/attachments`, {
-          method: "POST",
-          credentials: "include",
-          body: formData,
-        });
-        
+        const uploadRes = await permissionedFetch(
+          `${API}/api/v1/tickets/${ticketId}/attachments`,
+          {
+            method: "POST",
+            credentials: "include",
+            body: formData,
+          },
+          {
+            feature: "upload attachments",
+            hideSignInCta: Boolean(user && user.role !== "Anonymous"),
+          }
+        );
+
+        if (!uploadRes) {
+          setSubmitting(false);
+          return;
+        }
+
         if (!uploadRes.ok) {
           const errorData = await uploadRes.text();
           console.error("Failed to upload attachments:", errorData);

--- a/apps/web/hooks/usePermissionAwareFetch.ts
+++ b/apps/web/hooks/usePermissionAwareFetch.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useCallback } from "react";
+import { useUnauthorizedModal } from "@/lib/unauthorized-modal";
+
+interface PermissionAwareOptions {
+  feature?: string;
+  message?: string;
+  signInPath?: string;
+  hideSignInCta?: boolean;
+  primaryActionLabel?: string;
+}
+
+export function usePermissionAwareFetch() {
+  const { showUnauthorizedModal } = useUnauthorizedModal();
+
+  return useCallback(
+    async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+      options?: PermissionAwareOptions
+    ) => {
+      const response = await fetch(input, init);
+
+      if (response.status === 401 || response.status === 403) {
+        const feature = options?.feature;
+        const defaultMessage = feature
+          ? `You don't have permission to ${feature}.`
+          : "You don't have permission to perform this action.";
+
+        let signInPath = options?.signInPath;
+        if (!options?.hideSignInCta && !signInPath && typeof window !== "undefined") {
+          const [maybeLocale] = window.location.pathname.split("/").filter(Boolean);
+          const locale = maybeLocale || "en";
+          const redirectTarget = `${window.location.pathname}${window.location.search}`;
+          signInPath = `/${locale}/sign-in?redirect=${encodeURIComponent(redirectTarget || "/dashboard")}`;
+        }
+
+        showUnauthorizedModal({
+          description: options?.message ?? `${defaultMessage} Please sign in with an account that has the appropriate permissions or reach out to your administrator for access.`,
+          primaryAction: options?.hideSignInCta
+            ? undefined
+            : signInPath
+              ? {
+                  label: options?.primaryActionLabel ?? "Go to sign-in",
+                  href: signInPath,
+                }
+              : undefined,
+        });
+
+        return null;
+      }
+
+      return response;
+    },
+    [showUnauthorizedModal]
+  );
+}

--- a/apps/web/lib/unauthorized-modal.tsx
+++ b/apps/web/lib/unauthorized-modal.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { createContext, ReactNode, useCallback, useContext, useMemo, useState } from "react";
+import { Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, Button } from "@heroui/react";
+import { ShieldAlert } from "lucide-react";
+
+interface ModalAction {
+  label: string;
+  href?: string;
+  onPress?: () => void;
+}
+
+interface UnauthorizedModalState {
+  isOpen: boolean;
+  title: string;
+  description: string;
+  primaryAction?: ModalAction;
+  secondaryLabel?: string;
+}
+
+interface UnauthorizedModalContextValue {
+  showUnauthorizedModal: (options?: Partial<Omit<UnauthorizedModalState, "isOpen">>) => void;
+  hideUnauthorizedModal: () => void;
+}
+
+const UnauthorizedModalContext = createContext<UnauthorizedModalContextValue | undefined>(undefined);
+
+const defaultState: UnauthorizedModalState = {
+  isOpen: false,
+  title: "Access restricted",
+  description: "You don't have permission to perform this action. Please sign in or contact your administrator if you believe this is a mistake.",
+  primaryAction: undefined,
+  secondaryLabel: "Close"
+};
+
+export function UnauthorizedModalProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<UnauthorizedModalState>(defaultState);
+
+  const showUnauthorizedModal = useCallback((options?: Partial<Omit<UnauthorizedModalState, "isOpen">>) => {
+    setState({
+      ...defaultState,
+      ...options,
+      isOpen: true,
+      title: options?.title ?? defaultState.title,
+      description: options?.description ?? defaultState.description,
+      secondaryLabel: options?.secondaryLabel ?? defaultState.secondaryLabel,
+      primaryAction: options?.primaryAction,
+    });
+  }, []);
+
+  const hideUnauthorizedModal = useCallback(() => {
+    setState(prev => ({ ...prev, isOpen: false }));
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      showUnauthorizedModal,
+      hideUnauthorizedModal,
+    }),
+    [showUnauthorizedModal, hideUnauthorizedModal]
+  );
+
+  const handlePrimaryAction = useCallback(() => {
+    const action = state.primaryAction;
+    if (!action) {
+      hideUnauthorizedModal();
+      return;
+    }
+
+    if (action.onPress) {
+      action.onPress();
+    } else if (action.href) {
+      window.location.href = action.href;
+    }
+
+    hideUnauthorizedModal();
+  }, [state.primaryAction, hideUnauthorizedModal]);
+
+  return (
+    <UnauthorizedModalContext.Provider value={value}>
+      {children}
+      <Modal
+        isOpen={state.isOpen}
+        onOpenChange={(isOpen) => !isOpen && hideUnauthorizedModal()}
+        classNames={{
+          base: "bg-[#0f172a]/90 backdrop-blur-xl border border-white/10 text-white", // slate-900
+          header: "pb-0",
+          body: "pt-3",
+        }}
+      >
+        <ModalContent>
+          <ModalHeader>
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-xl bg-gradient-to-br from-rose-500/80 via-orange-500/80 to-amber-400/80 text-white shadow-lg">
+                <ShieldAlert size={24} />
+              </div>
+              <div>
+                <p className="text-sm uppercase tracking-wide text-white/70">Permission needed</p>
+                <h3 className="text-xl font-semibold text-white">{state.title}</h3>
+              </div>
+            </div>
+          </ModalHeader>
+          <ModalBody>
+            <p className="text-white/70 leading-relaxed">
+              {state.description}
+            </p>
+            <div className="rounded-2xl bg-white/[0.04] border border-white/10 p-4 space-y-3">
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-full bg-gradient-to-br from-purple-500/30 to-indigo-500/30 flex items-center justify-center">
+                  <span className="text-lg">🔒</span>
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-white/90">Why am I seeing this?</p>
+                  <p className="text-xs text-white/60">
+                    This action is limited to users with elevated permissions. Sign in with an authorized account or reach out to your team lead for access.
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 text-xs text-white/50">
+                <div className="flex items-center gap-1">
+                  <span className="text-sm">•</span>
+                  <span>Authentication required for sensitive data</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <span className="text-sm">•</span>
+                  <span>Role-based access control enforced</span>
+                </div>
+              </div>
+            </div>
+          </ModalBody>
+          <ModalFooter>
+            <div className="flex flex-1 flex-col sm:flex-row sm:items-center gap-3">
+              <Button
+                variant="light"
+                className="text-white/70 hover:text-white"
+                onPress={hideUnauthorizedModal}
+                fullWidth
+              >
+                {state.secondaryLabel ?? "Close"}
+              </Button>
+              {state.primaryAction && (
+                <Button
+                  color="primary"
+                  className="bg-gradient-to-r from-rose-500 via-purple-500 to-indigo-500 text-white font-semibold shadow-lg shadow-purple-500/40"
+                  onPress={handlePrimaryAction}
+                  fullWidth
+                >
+                  {state.primaryAction.label}
+                </Button>
+              )}
+            </div>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </UnauthorizedModalContext.Provider>
+  );
+}
+
+export function useUnauthorizedModal() {
+  const context = useContext(UnauthorizedModalContext);
+  if (!context) {
+    throw new Error("useUnauthorizedModal must be used within an UnauthorizedModalProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- add an UnauthorizedModalProvider with a polished access restriction dialog and expose a reusable permission-aware fetch hook
- wrap the locale layout with the modal provider so the dialog is available app-wide
- update ticket workflows (classification, profile updates, creation, detail actions, downloads) to call the permission-aware fetch helper and surface the modal on unauthorized responses

## Testing
- pnpm --filter @it-tms/web lint *(fails: eslint parser is not configured for the existing TypeScript sources)*

------
https://chatgpt.com/codex/tasks/task_e_68d4dbd9a2cc832e855ad284cbe0c78f