### PR TITLE
Allow users to create all ticket types

### DIFF
--- a/apps/api/internal/http/handlers/handlers.go
+++ b/apps/api/internal/http/handlers/handlers.go
@@ -293,11 +293,7 @@ func (h *Handlers) TicketsCreate(c *fiber.Ctx) error {
 			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": fiber.Map{"code": "FORBIDDEN", "message": "anonymous can only open issue reports"}})
 		}
 	case "User":
-		// Users can create all types except Data Correction (Emergency Change doesn't exist in enums)
-		if body.InitialType == models.InitialServiceDataCorrection {
-			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": fiber.Map{"code": "FORBIDDEN", "message": "insufficient permissions for this ticket type"}})
-		}
-		// All other types are allowed for Users
+		// Users can create all ticket types
 	case "Supervisor", "Manager":
 		// Supervisors and Managers can create all types
 		// No restrictions

--- a/apps/api/internal/http/handlers/handlers_test.go
+++ b/apps/api/internal/http/handlers/handlers_test.go
@@ -129,11 +129,10 @@ func TestRBAC_TicketCreation(t *testing.T) {
 			expectedStatus: 500, // Will fail due to mock DB, but should not be forbidden
 		},
 		{
-			name:           "User cannot create Data Correction",
+			name:           "User can create Data Correction",
 			userRole:       "User",
 			ticketType:     "SERVICE_REQUEST_DATA_CORRECTION",
-			expectedStatus: 403,
-			expectedError:  "insufficient permissions for this ticket type",
+			expectedStatus: 500, // Will fail due to mock DB, but should not be forbidden
 		},
 		{
 			name:           "Supervisor can create any ticket type",


### PR DESCRIPTION
## Summary
- update ticket creation RBAC to allow the User role to open any ticket type
- adjust RBAC tests to expect successful creation of data correction tickets by regular users

## Testing
- GOTOOLCHAIN=local go test ./internal/http/handlers -run TestRBAC_TicketCreation -count=1 -v *(fails: panic from pgxpool nil connection in existing test setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d4eaa6900c832e833b4b5e46e291eb