### PR TITLE
Exclude hidden comments from latest comment lookup

### DIFF
--- a/apps/api/internal/repositories/metrics.go
+++ b/apps/api/internal/repositories/metrics.go
@@ -55,7 +55,7 @@ func (r *MetricsRepo) SummaryWithDateFilter(ctx context.Context, month *int, yea
 			t.assignee_id,
 			u.name as assignee_name,
 			t.updated_at,
-			(SELECT c.body FROM comments c WHERE c.ticket_id = t.id ORDER BY c.created_at DESC LIMIT 1) as latest_comment,
+(SELECT c.body FROM comments c WHERE c.ticket_id = t.id AND c.is_hidden = FALSE ORDER BY c.created_at DESC LIMIT 1) as latest_comment,
 			(SELECT STRING_AGG(au.name, ', ' ORDER BY au.name) 
 			 FROM ticket_assignments ta 
 			 JOIN users au ON ta.assignee_id = au.id 

--- a/apps/api/internal/repositories/tickets.go
+++ b/apps/api/internal/repositories/tickets.go
@@ -81,7 +81,7 @@ func (r *TicketRepo) List(ctx context.Context, f TicketFilters, offset, limit in
 	where := strings.Join(clauses, " AND ")
 	sql := fmt.Sprintf(`SELECT 
 		t.id, t.code, t.created_by, t.initial_type, t.resolved_type, t.status, t.title, t.description, t.details, t.impact_score, t.urgency_score, t.final_score, t.red_flag, t.priority, t.assignee_id, t.effort_data, t.effort_score, t.created_at, t.updated_at, t.closed_at,
-		(SELECT c.body FROM comments c WHERE c.ticket_id = t.id ORDER BY c.created_at DESC LIMIT 1) as latest_comment
+(SELECT c.body FROM comments c WHERE c.ticket_id = t.id AND c.is_hidden = FALSE ORDER BY c.created_at DESC LIMIT 1) as latest_comment
 	FROM tickets t WHERE %s ORDER BY 
 		CASE t.priority 
 			WHEN 'P0' THEN 0 
@@ -161,7 +161,7 @@ func (r *TicketRepo) GetByID(ctx context.Context, id string) (models.Ticket, err
 	var latestComment *string
 	row := r.pool.QueryRow(ctx, `SELECT 
         t.id, t.code, t.created_by, t.initial_type, t.resolved_type, t.status, t.title, t.description, t.details, t.impact_score, t.urgency_score, t.final_score, t.red_flag, t.priority, t.assignee_id, t.red_flags_data, t.impact_assessment_data, t.urgency_timeline_data, t.effort_data, t.effort_score, t.created_at, t.updated_at, t.closed_at,
-		(SELECT c.body FROM comments c WHERE c.ticket_id = t.id ORDER BY c.created_at DESC LIMIT 1) as latest_comment
+(SELECT c.body FROM comments c WHERE c.ticket_id = t.id AND c.is_hidden = FALSE ORDER BY c.created_at DESC LIMIT 1) as latest_comment
 	FROM tickets t WHERE t.id=$1`, id)
 	if err := row.Scan(&t.ID, &t.Code, &t.CreatedBy, &t.InitialType, &t.ResolvedType, &t.Status, &t.Title, &t.Description, &details, &t.ImpactScore, &t.UrgencyScore, &t.FinalScore, &t.RedFlag, &t.Priority, &t.AssigneeID, &redFlagsData, &impactAssessmentData, &urgencyTimelineData, &effortData, &t.EffortScore, &t.CreatedAt, &t.UpdatedAt, &t.ClosedAt, &latestComment); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -184,7 +184,7 @@ func (r *TicketRepo) GetWithRelations(ctx context.Context, id string) (models.Ti
 	var latestComment *string
 	row := r.pool.QueryRow(ctx, `SELECT 
         t.id, t.code, t.created_by, t.initial_type, t.resolved_type, t.status, t.title, t.description, t.details, t.impact_score, t.urgency_score, t.final_score, t.red_flag, t.priority, t.assignee_id, t.red_flags_data, t.impact_assessment_data, t.urgency_timeline_data, t.effort_data, t.effort_score, t.created_at, t.updated_at, t.closed_at,
-		(SELECT c.body FROM comments c WHERE c.ticket_id = t.id ORDER BY c.created_at DESC LIMIT 1) as latest_comment
+(SELECT c.body FROM comments c WHERE c.ticket_id = t.id AND c.is_hidden = FALSE ORDER BY c.created_at DESC LIMIT 1) as latest_comment
 	FROM tickets t WHERE t.id=$1`, id)
 	if err := row.Scan(&t.ID, &t.Code, &t.CreatedBy, &t.InitialType, &t.ResolvedType, &t.Status, &t.Title, &t.Description, &details, &t.ImpactScore, &t.UrgencyScore, &t.FinalScore, &t.RedFlag, &t.Priority, &t.AssigneeID, &redFlagsData, &impactAssessmentData, &urgencyTimelineData, &effortData, &t.EffortScore, &t.CreatedAt, &t.UpdatedAt, &t.ClosedAt, &latestComment); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {


### PR DESCRIPTION
## Summary
- update ticket repository queries to ignore hidden comments when retrieving the latest comment
- update metrics summary query to also ignore hidden comments when fetching the latest comment text

## Testing
- go test ./... *(fails: command hangs waiting for database connection in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d524771590832ea46a75d321864563