### PR TITLE
Use icon for ticket attachment removal

### DIFF
--- a/apps/web/app/[locale]/tickets/[id]/page.tsx
+++ b/apps/web/app/[locale]/tickets/[id]/page.tsx
@@ -12,14 +12,15 @@ import EffortAssessmentExplanation from "@/components/EffortAssessmentExplanatio
 import TicketCompletionCelebration from "@/components/TicketCompletionCelebration";
 import { useTranslations, useLocale } from 'next-intl';
 import { usePermissionAwareFetch } from '@/hooks/usePermissionAwareFetch';
-import { 
-  AlertTriangle, 
-  Paperclip, 
-  MessageSquare, 
-  RotateCcw, 
-  Users, 
+import {
+  AlertTriangle,
+  Paperclip,
+  MessageSquare,
+  RotateCcw,
+  Users,
   Flag,
-  Settings
+  Settings,
+  X
 } from "lucide-react";
 
 // Use current hostname with port 8000 for production-like environment
@@ -1096,9 +1097,10 @@ export default function TicketDetails() {
                           <button
                             type="button"
                             onClick={() => setAttachmentFiles(prev => prev.filter((_, i) => i !== index))}
-                            className="text-red-400 hover:text-red-300"
+                            className="text-red-400 hover:text-red-300 flex items-center justify-center"
+                            aria-label={t('remove')}
                           >
-                            {t('remove')}
+                            <X className="w-4 h-4" aria-hidden="true" />
                           </button>
                         </div>
                       ))}
@@ -1151,10 +1153,18 @@ export default function TicketDetails() {
                           <button
                             type="button"
                             onClick={() => removeTicketAttachment(att.id)}
-                            className="text-red-300 hover:text-red-200 text-xs"
+                            className="text-red-300 hover:text-red-200 text-xs flex items-center justify-center"
                             disabled={isRemoving}
+                            aria-label={t('remove')}
                           >
-                            {isRemoving ? 'Removing…' : t('remove')}
+                            {isRemoving ? (
+                              <div
+                                className="w-4 h-4 border-2 border-red-200/80 border-t-transparent rounded-full animate-spin"
+                                aria-hidden="true"
+                              />
+                            ) : (
+                              <X className="w-4 h-4" aria-hidden="true" />
+                            )}
                           </button>
                         )}
                       </div>


### PR DESCRIPTION
## Summary
- replace text-based remove actions on ticket attachments with a red X icon
- show a spinner while an attachment removal request is in progress

## Testing
- pnpm --filter @it-tms/web lint *(fails: existing eslint parser errors across the app)*

------
https://chatgpt.com/codex/tasks/task_e_68d52f868e74832ead486692e7533bbb