### PR TITLE
Fix duplicate constant in unauthorized modal

### DIFF
--- a/apps/web/lib/unauthorized-modal.tsx
+++ b/apps/web/lib/unauthorized-modal.tsx
@@ -11,12 +11,6 @@ function classNames(...classes: Array<string | false | null | undefined>) {
   return classes.filter(Boolean).join(" ");
 }
 
-const THAI_FONT_CLASS = "font-['IBM_Plex_Sans_Thai']";
-
-function cx(...classes: (string | undefined)[]) {
-  return classes.filter(Boolean).join(" ");
-}
-
 function BilingualText({
   as: Component = "span",
   en,
@@ -34,8 +28,8 @@ function BilingualText({
 }) {
   return (
     <Component className={className}>
-      <span className={cx("block", englishClassName)}>{en}</span>
-      <span className={cx("block", THAI_FONT_CLASS, thaiClassName)}>{th}</span>
+      <span className={classNames("block", englishClassName)}>{en}</span>
+      <span className={classNames("block", THAI_FONT_CLASS, thaiClassName)}>{th}</span>
     </Component>
   );
 }


### PR DESCRIPTION
## Summary
- remove the duplicate THAI_FONT_CLASS declaration in the unauthorized modal helper
- reuse the existing classNames helper in BilingualText to avoid redundant helpers

## Testing
- pnpm --filter @it-tms/web lint *(fails: existing parsing errors across the app unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d537ddbb24832ebe59f64e57a464ca