### PR TITLE
fix: allow cross-origin attachment downloads

### DIFF
--- a/apps/web/app/[locale]/tickets/[id]/page.tsx
+++ b/apps/web/app/[locale]/tickets/[id]/page.tsx
@@ -870,6 +870,22 @@ export default function TicketDetails() {
 
     try {
       const hideSignInCta = Boolean(user && user.role !== "Anonymous");
+
+      if (typeof window !== "undefined") {
+        try {
+          const resolvedUrl = new URL(url, window.location.href);
+
+          if (resolvedUrl.origin !== window.location.origin) {
+            window.open(resolvedUrl.toString(), "_blank", "noopener,noreferrer");
+            return;
+          }
+        } catch (error) {
+          console.warn("Falling back to direct download for attachment URL", error);
+          window.open(url, "_blank", "noopener,noreferrer");
+          return;
+        }
+      }
+
       const response = await permissionedFetch(
         url,
         { credentials: "include" },


### PR DESCRIPTION
## Summary
- open cross-origin attachment URLs in a new tab before attempting fetch to avoid CSP blocks
- fall back gracefully when resolving the URL fails so users can still download files

## Testing
- `pnpm lint` *(fails: eslint parsing errors present in existing source files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c189f3c8832e9710ec284dabdc47