### PR TITLE
Fix classify endpoint path and add tracker classification comments

### DIFF
--- a/apps/api/cmd/server/main.go
+++ b/apps/api/cmd/server/main.go
@@ -145,7 +145,7 @@ func main() {
 	v1.Get("/profile-pictures/:profilePictureId/download", h.DownloadProfilePicture)
 
 	// Admin routes (require Supervisor or Manager roles)
-	admin := v1.Group("/", middleware.RequireSupervisorOrManager(cfg.JWTSecret))
+	admin := v1.Group("", middleware.RequireSupervisorOrManager(cfg.JWTSecret))
 	admin.Post("/tickets/:id/classify", h.TicketsClassify)
 	admin.Put("/tickets/:id/red-flags", h.TicketsUpdateRedFlags)
 	admin.Put("/tickets/:id/impact-assessment", h.TicketsUpdateImpactAssessment)

--- a/apps/api/internal/http/handlers/handlers.go
+++ b/apps/api/internal/http/handlers/handlers.go
@@ -1919,17 +1919,19 @@ func (h *Handlers) TicketsClassify(c *fiber.Ctx) error {
 	}
 
 	ctx := context.Background()
-	userClaims, _ := c.Locals("user").(jwt.MapClaims)
+	userIDValue, role, ok := middleware.GetUserFromContext(c)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": fiber.Map{"code": "UNAUTHORIZED", "message": "auth required"}})
+	}
+	actorDisplay := getUserDisplayName(c, role)
 	var userID *string
-	if userClaims != nil {
-		if sid, ok := userClaims["sub"].(string); ok {
-			userID = &sid
-		}
+	if userIDValue != "" {
+		userID = &userIDValue
 	}
 
 	if body.Reject != nil && *body.Reject {
 		// Handle rejection by setting status to canceled
-		if err := h.repo.Tickets.RejectIssueReport(ctx, id); err != nil {
+		if err := h.repo.Tickets.RejectIssueReport(ctx, id, actorDisplay); err != nil {
 			if errors.Is(err, repositories.ErrNotFound) {
 				return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": fiber.Map{"code": "NOT_FOUND", "message": "ticket not found"}})
 			}
@@ -1939,7 +1941,7 @@ func (h *Handlers) TicketsClassify(c *fiber.Ctx) error {
 		return c.JSON(h.envelope(fiber.Map{"id": id, "status": "rejected"}))
 	} else {
 		// Handle normal classification
-		if err := h.repo.Tickets.Classify(ctx, id, *body.ResolvedType); err != nil {
+		if err := h.repo.Tickets.Classify(ctx, id, *body.ResolvedType, actorDisplay); err != nil {
 			if errors.Is(err, repositories.ErrNotFound) {
 				return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": fiber.Map{"code": "NOT_FOUND", "message": "ticket not found"}})
 			}

--- a/apps/api/internal/repositories/tickets.go
+++ b/apps/api/internal/repositories/tickets.go
@@ -665,7 +665,7 @@ func (r *TicketRepo) GetCommentAttachmentByID(ctx context.Context, attachmentID 
 	return attachment, nil
 }
 
-func (r *TicketRepo) Classify(ctx context.Context, id string, resolved models.TicketResolvedType) error {
+func (r *TicketRepo) Classify(ctx context.Context, id string, resolved models.TicketResolvedType, actorName string) error {
 	// only classify Issue Report
 	row := r.pool.QueryRow(ctx, `SELECT initial_type FROM tickets WHERE id=$1`, id)
 	var initial string
@@ -678,11 +678,15 @@ func (r *TicketRepo) Classify(ctx context.Context, id string, resolved models.Ti
 	if initial != string(models.InitialIssueReport) {
 		return errors.New("only ISSUE_REPORT can be classified")
 	}
-	_, err := r.pool.Exec(ctx, `UPDATE tickets SET resolved_type=$1, updated_at=NOW() WHERE id=$2`, resolved, id)
-	return err
+	if _, err := r.pool.Exec(ctx, `UPDATE tickets SET resolved_type=$1, updated_at=NOW() WHERE id=$2`, resolved, id); err != nil {
+		return err
+	}
+
+	commentBody := tracker.FormatComment(fmt.Sprintf("`%s` classified the issue report as `%s`", escapeMarkdown(actorName), escapeMarkdown(string(resolved))))
+	return r.AddSystemComment(ctx, id, commentBody)
 }
 
-func (r *TicketRepo) RejectIssueReport(ctx context.Context, id string) error {
+func (r *TicketRepo) RejectIssueReport(ctx context.Context, id string, actorName string) error {
 	// only reject Issue Report
 	row := r.pool.QueryRow(ctx, `SELECT initial_type FROM tickets WHERE id=$1`, id)
 	var initial string
@@ -696,8 +700,12 @@ func (r *TicketRepo) RejectIssueReport(ctx context.Context, id string) error {
 		return errors.New("only ISSUE_REPORT can be rejected")
 	}
 	now := time.Now()
-	_, err := r.pool.Exec(ctx, `UPDATE tickets SET status=$1, closed_at=$2, updated_at=NOW() WHERE id=$3`, models.StatusCanceled, &now, id)
-	return err
+	if _, err := r.pool.Exec(ctx, `UPDATE tickets SET status=$1, closed_at=$2, updated_at=NOW() WHERE id=$3`, models.StatusCanceled, &now, id); err != nil {
+		return err
+	}
+
+	commentBody := tracker.FormatComment(fmt.Sprintf("`%s` rejected the issue report", escapeMarkdown(actorName)))
+	return r.AddSystemComment(ctx, id, commentBody)
 }
 
 // Multi-assignee methods


### PR DESCRIPTION
## Summary
- ensure the supervisor/manager API group registers routes under `/api/v1` so classifying tickets no longer hits a 404
- require a valid authenticated actor when classifying or rejecting and record their action with tracker system comments

## Testing
- `go test ./...` *(fails: interrupted during long dependency compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d276fe5c832e88243f19845ee023