### PR TITLE
Refine canceled tickets filter toggle layout

### DIFF
--- a/apps/web/app/[locale]/tickets/page.tsx
+++ b/apps/web/app/[locale]/tickets/page.tsx
@@ -271,26 +271,24 @@ export default function TicketsPage() {
               />
             </div>
             <div className="md:col-span-2 lg:col-span-1 xl:col-span-1">
-              <div className="flex w-full items-center justify-between gap-4 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 shadow-sm backdrop-blur-md">
-                <div className="flex flex-col">
-                  <span className="text-xs font-medium uppercase tracking-wider text-white/60">{t('status.canceled')}</span>
-                  <span className="text-sm font-semibold text-white">{t('showCanceled')}</span>
-                </div>
-                <Switch
-                  isSelected={includeCanceled}
-                  onValueChange={setIncludeCanceled}
-                  size="sm"
-                  color="danger"
-                  aria-label={t('showCanceled')}
-                  classNames={{
-                    base: "m-0 p-0",
-                    wrapper: "h-6 w-11 bg-white/20 data-[selected=true]:bg-danger-500/80",
-                    thumb: "h-5 w-5 bg-white shadow-md",
-                  }}
-                  startContent={<XCircle className="h-3.5 w-3.5 text-white" />}
-                  endContent={<CheckCircle className="h-3.5 w-3.5 text-white" />}
-                />
-              </div>
+              <Switch
+                isSelected={includeCanceled}
+                onValueChange={setIncludeCanceled}
+                size="sm"
+                color="success"
+                aria-label={t('showCanceled')}
+                classNames={{
+                  base: "m-0 flex w-full items-center justify-between gap-4 rounded-2xl border border-white/10 bg-white/5 px-4 py-2 shadow-sm backdrop-blur-md",
+                  wrapper: "order-last h-5 w-10 rounded-full bg-white/20 data-[selected=true]:bg-success-500/80",
+                  thumb: "h-4 w-4 bg-white shadow-md",
+                  label: "flex flex-col gap-0.5 text-left leading-tight",
+                }}
+                startContent={<XCircle className="h-3.5 w-3.5 text-white" />}
+                endContent={<CheckCircle className="h-3.5 w-3.5 text-white" />}
+              >
+                <span className="text-xs font-medium uppercase tracking-wider text-white/60">{t('status.canceled')}</span>
+                <span className="text-sm font-semibold text-white">{t('showCanceled')}</span>
+              </Switch>
             </div>
           </CardBody>
         </Card>


### PR DESCRIPTION
## Summary
- inline the canceled tickets switch container styling into the Switch so its overall height matches adjacent filters
- keep the success-colored track and tighten the label layout for a balanced two-line title/description

## Testing
- pnpm lint --filter @it-tms/web *(fails: existing eslint parser errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5e8927d1c832eb9f3a8cc269d7286