### PR TITLE
Fix classification actions to use supported API routes

### DIFF
--- a/apps/web/app/[locale]/admin/classify/page.tsx
+++ b/apps/web/app/[locale]/admin/classify/page.tsx
@@ -92,17 +92,19 @@ export default function ClassifyPage() {
     const rt = sel[id];
     if (!rt) return;
     
-    let payload: any;
-    if (rt === "REJECT") {
-      payload = { reject: true };
-    } else {
-      payload = { resolvedType: rt };
-    }
-    
+    const isRejecting = rt === "REJECT";
+    const endpoint = isRejecting
+      ? `${API}/api/v1/tickets/${id}/status`
+      : `${API}/api/v1/tickets/${id}/fields`;
+    const method = isRejecting ? "POST" : "PATCH";
+    const payload = isRejecting
+      ? { status: "canceled" }
+      : { resolvedType: rt };
+
     const response = await permissionedFetch(
-      `${API}/api/v1/tickets/${id}/classify`,
+      endpoint,
       {
-        method: "POST",
+        method,
         credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- switch the classify action to reuse the ticket status and field update endpoints instead of the missing `/classify` API route
- send a cancel status when rejecting and a resolvedType field update when accepting so the UI immediately removes the processed ticket

## Testing
- `pnpm --filter @it-tms/web lint` *(fails: repository ESLint configuration reports parsing errors across many files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ea31a8dc832e8fd2f536ecc21b2b