### PR TITLE
Fix ticket detail markdown rendering

### DIFF
--- a/apps/web/app/[locale]/admin/classify/page.tsx
+++ b/apps/web/app/[locale]/admin/classify/page.tsx
@@ -4,7 +4,7 @@ import { Card, CardBody, CardHeader, Button, Select, SelectItem, Chip, Modal, Mo
 import { Tags, CheckCircle, Info, Eye, Calendar, User, Phone, Mail, AlertTriangle } from "lucide-react";
 import { useTranslations } from 'next-intl';
 import { ReadOnlyMarkdownEditor } from '@/lib/read-only-markdown-editor';
-import { convertContentToMarkdown, convertContentToHtml } from '@/lib/html-to-markdown';
+import { convertContentToHtml } from '@/lib/html-to-markdown';
 import { usePermissionAwareFetch } from '@/hooks/usePermissionAwareFetch';
 import {
   filterClassifiableIssueReports,
@@ -321,8 +321,8 @@ export default function ClassifyPage() {
                       </h5>
                       <div className="bg-default-100 rounded-lg p-4">
                         {selectedTicket.description ? (
-                          <ReadOnlyMarkdownEditor 
-                            content={convertContentToMarkdown(selectedTicket.description)}
+                          <ReadOnlyMarkdownEditor
+                            content={convertContentToHtml(selectedTicket.description)}
                             className="text-sm"
                           />
                         ) : (

--- a/apps/web/app/[locale]/dashboard/page.tsx
+++ b/apps/web/app/[locale]/dashboard/page.tsx
@@ -5,7 +5,7 @@ import dynamic from "next/dynamic";
 import { AlertTriangle, Clipboard, PartyPopper, Clock, BarChart3, FolderOpen, Zap, Trophy, Star, Award, Calendar, Filter } from "lucide-react";
 import { useTranslations, useLocale } from 'next-intl';
 import { ReadOnlyMarkdownEditor } from '@/lib/read-only-markdown-editor';
-import { convertContentToMarkdown, convertContentToHtml } from '@/lib/html-to-markdown';
+import { convertContentToHtml } from '@/lib/html-to-markdown';
 
 // Import the Chart.js pie chart component with SSR disabled
 const ChartJsPieChart = dynamic(() => import("@/components/ChartJsPieChart"), {

--- a/apps/web/app/[locale]/tickets/[id]/page.tsx
+++ b/apps/web/app/[locale]/tickets/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useParams } from "next/navigation";
 import { Card, CardBody, CardHeader, Button, Textarea, Input, Chip, Divider, Select, SelectItem, Checkbox, Avatar } from "@heroui/react";
 import { TiptapEditor } from "@/lib/tiptap-editor";
 import { ReadOnlyMarkdownEditor } from "@/lib/read-only-markdown-editor";
-import { convertContentToMarkdown, convertContentToHtml } from "@/lib/html-to-markdown";
+import { convertContentToHtml } from "@/lib/html-to-markdown";
 import { useAuth } from "@/lib/auth";
 import { computePriority, PriorityInput } from "@/lib/priority";
 import UserSearchSelect from "@/components/UserSearchSelect";
@@ -1166,8 +1166,8 @@ export default function TicketDetails() {
             <div>
               <h3 className="text-lg font-semibold mb-3">{t('description')}</h3>
               {!isEditingContent ? (
-                <ReadOnlyMarkdownEditor 
-                  content={convertContentToMarkdown(ticket.description)}
+                <ReadOnlyMarkdownEditor
+                  content={convertContentToHtml(ticket.description)}
                   className="text-white/80 leading-relaxed"
                 />
               ) : (
@@ -1189,7 +1189,7 @@ export default function TicketDetails() {
                   {!isEditingContent ? (
                     ticket.details?.steps ? (
                       <ReadOnlyMarkdownEditor
-                        content={convertContentToMarkdown(ticket.details.steps)}
+                        content={convertContentToHtml(ticket.details.steps)}
                         className="text-white/80 leading-relaxed"
                       />
                     ) : (

--- a/apps/web/app/[locale]/tickets/page.tsx
+++ b/apps/web/app/[locale]/tickets/page.tsx
@@ -6,7 +6,7 @@ import UserSearchSelect from "@/components/UserSearchSelect";
 import { useTranslations, useLocale } from 'next-intl';
 import { useAuth } from "@/lib/auth";
 import { ReadOnlyMarkdownEditor } from '@/lib/read-only-markdown-editor';
-import { convertContentToMarkdown, convertContentToHtml } from '@/lib/html-to-markdown';
+import { convertContentToHtml } from '@/lib/html-to-markdown';
 
 // Use current hostname with port 8000 for production-like environment
 const API = typeof window !== 'undefined' && window.location.port === '8000'


### PR DESCRIPTION
## Summary
- render ticket descriptions and steps through HTML conversion so stored markdown displays correctly in the read-only editor
- apply the same HTML conversion in the admin classify view to keep ticket previews consistent
- remove unused markdown conversion imports from ticket and dashboard pages

## Testing
- pnpm --filter web lint *(fails: existing parsing errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d7921f5e28832ebfd007af0c087160