### PR TITLE
Fix TypeScript typings for TipTap image extensions

### DIFF
--- a/apps/web/lib/knowledge-sharing-editor.tsx
+++ b/apps/web/lib/knowledge-sharing-editor.tsx
@@ -32,13 +32,21 @@ import {
 import { Button, Input, Progress } from '@heroui/react';
 
 // Custom Image extension with alignment support
+type ImageAttributes = {
+  src?: string | null;
+  alt?: string | null;
+  title?: string | null;
+  align?: string | null;
+  width?: string | null;
+};
+
 const ImageWithAlignment = Image.extend({
   addAttributes() {
     return {
       src: {
         default: null,
         parseHTML: (element: HTMLElement) => element.getAttribute('src'),
-        renderHTML: attributes => {
+        renderHTML: (attributes: ImageAttributes) => {
           if (!attributes.src) {
             return {};
           }
@@ -50,7 +58,7 @@ const ImageWithAlignment = Image.extend({
       alt: {
         default: null,
         parseHTML: (element: HTMLElement) => element.getAttribute('alt'),
-        renderHTML: attributes => {
+        renderHTML: (attributes: ImageAttributes) => {
           if (!attributes.alt) {
             return {};
           }
@@ -62,7 +70,7 @@ const ImageWithAlignment = Image.extend({
       title: {
         default: null,
         parseHTML: (element: HTMLElement) => element.getAttribute('title'),
-        renderHTML: attributes => {
+        renderHTML: (attributes: ImageAttributes) => {
           if (!attributes.title) {
             return {};
           }
@@ -74,7 +82,7 @@ const ImageWithAlignment = Image.extend({
       align: {
         default: 'center',
         parseHTML: (element: HTMLElement) => element.getAttribute('data-align') || 'center',
-        renderHTML: attributes => {
+        renderHTML: (attributes: ImageAttributes) => {
           return {
             'data-align': attributes.align || 'center',
           };
@@ -83,7 +91,7 @@ const ImageWithAlignment = Image.extend({
       width: {
         default: null,
         parseHTML: (element: HTMLElement) => element.getAttribute('width'),
-        renderHTML: attributes => {
+        renderHTML: (attributes: ImageAttributes) => {
           if (!attributes.width) {
             return {};
           }
@@ -97,7 +105,13 @@ const ImageWithAlignment = Image.extend({
   addCommands() {
     return {
       setImage: (options: { src: string; align?: string; width?: string }) => {
-        return ({ commands }) => {
+        return ({
+          commands,
+        }: {
+          commands: {
+            insertContent: (content: unknown) => boolean;
+          };
+        }) => {
           return commands.insertContent({
             type: this.name,
             attrs: {

--- a/apps/web/lib/read-only-markdown-editor.tsx
+++ b/apps/web/lib/read-only-markdown-editor.tsx
@@ -7,15 +7,24 @@ import { TextAlign } from '@tiptap/extension-text-align';
 import { Highlight } from '@tiptap/extension-highlight';
 import { Image } from '@tiptap/extension-image';
 
+type ImageAttributes = {
+  align?: string | null;
+  width?: string | null;
+};
+
 // Custom Image extension with alignment support (same as in knowledge-sharing-editor)
 const ImageWithAlignment = Image.extend({
   addAttributes() {
+    const parent = (this as unknown as typeof Image & {
+      parent?: () => Record<string, unknown>;
+    }).parent;
+
     return {
-      ...this.parent?.(),
+      ...(typeof parent === 'function' ? parent() : {}),
       align: {
         default: 'center',
-        parseHTML: element => element.getAttribute('data-align') || 'center',
-        renderHTML: attributes => {
+        parseHTML: (element: HTMLElement) => element.getAttribute('data-align') || 'center',
+        renderHTML: (attributes: ImageAttributes) => {
           return {
             'data-align': attributes.align || 'center',
           };
@@ -23,8 +32,8 @@ const ImageWithAlignment = Image.extend({
       },
       width: {
         default: null,
-        parseHTML: element => element.getAttribute('width'),
-        renderHTML: attributes => {
+        parseHTML: (element: HTMLElement) => element.getAttribute('width'),
+        renderHTML: (attributes: ImageAttributes) => {
           if (!attributes.width) {
             return {};
           }


### PR DESCRIPTION
## Summary
- add explicit image attribute types for the knowledge sharing editor
- improve the TipTap image extension typing in the read-only editor to avoid implicit anys
- tighten the setImage command definition to ensure the insertContent helper is typed

## Testing
- pnpm --filter @it-tms/web typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dba8c1d404832eb6eb0ba2d519dbd4