### PR TITLE
Remove back navigation buttons from knowledge sharing detail and edit

### DIFF
--- a/apps/web/app/[locale]/knowledge-sharing/[id]/edit/page.tsx
+++ b/apps/web/app/[locale]/knowledge-sharing/[id]/edit/page.tsx
@@ -419,15 +419,6 @@ export default function EditKnowledgeSharingPage() {
                     {t('deleteDocument')}
                   </Button>
                 )}
-                
-                <Button
-                  variant="ghost"
-                  size="lg"
-                  onPress={() => router.push(`/knowledge-sharing/${documentId}` as any)}
-                  className="w-full"
-                >
-                  {t('cancel')}
-                </Button>
               </div>
             </CardBody>
           </Card>

--- a/apps/web/app/[locale]/knowledge-sharing/[id]/page.tsx
+++ b/apps/web/app/[locale]/knowledge-sharing/[id]/page.tsx
@@ -4,14 +4,13 @@ import React, { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
 import { useAuth } from '../../../../lib/auth';
 import { Button, Card, CardBody, Avatar, Chip, Spinner } from '@heroui/react';
-import { 
-  Heart, 
-  Share2, 
-  Edit, 
-  Trash2, 
-  Users, 
-  Calendar, 
-  ArrowLeft,
+import {
+  Heart,
+  Share2,
+  Edit,
+  Trash2,
+  Users,
+  Calendar,
   Copy,
   Check,
   Eye,
@@ -244,15 +243,6 @@ export default function KnowledgeSharingDocumentPage() {
 
               {/* Actions */}
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                <Button
-                  color="primary"
-                  size="lg"
-                  startContent={<ArrowLeft className="w-4 h-4" />}
-                  onPress={() => router.push('/knowledge-sharing')}
-                  className="font-semibold"
-                >
-                  {t('goBackToKnowledgeSharing')}
-                </Button>
                 <Button
                   variant="bordered"
                   size="lg"


### PR DESCRIPTION
## Summary
- remove the go back action from the knowledge sharing document view error state
- drop the back/cancel action from the knowledge sharing edit page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbace41930832ea7f439b45fbd572c