### PR TITLE
Allow users to self-assign unassigned tickets

### DIFF
--- a/apps/api/internal/http/handlers/handlers.go
+++ b/apps/api/internal/http/handlers/handlers.go
@@ -882,9 +882,13 @@ func (h *Handlers) TicketsAssign(c *fiber.Ctx) error {
 	if body.Self {
 		assigneeIDs = []string{userID}
 	} else if len(body.AssigneeIDs) > 0 {
-		// Users can only self-assign
+		// Users can only assign themselves when using the new multi-assign payload
 		if role == "User" {
-			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": fiber.Map{"code": "FORBIDDEN", "message": "only supervisors/managers can assign others"}})
+			for _, assigneeID := range body.AssigneeIDs {
+				if assigneeID != userID {
+					return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": fiber.Map{"code": "FORBIDDEN", "message": "only supervisors/managers can assign others"}})
+				}
+			}
 		}
 		assigneeIDs = body.AssigneeIDs
 	} else if body.AssigneeID != nil {

--- a/apps/web/app/[locale]/tickets/[id]/page.tsx
+++ b/apps/web/app/[locale]/tickets/[id]/page.tsx
@@ -1976,8 +1976,11 @@ export default function TicketDetails() {
           )}
 
           {/* Self-Assignment for regular Users (only if not already assigned and not Supervisor/Manager) */}
-          {!canAssignTicket() && user && user.role === "User" && 
-           !data.ticket.assignees?.some((assignee: any) => assignee.id === user.id) && (
+          {!canAssignTicket() &&
+            user &&
+            user.role === "User" &&
+            (data.ticket.assignees?.length ?? 0) === 0 &&
+            !data.ticket.assignees?.some((assignee: any) => assignee.id === user.id) && (
             <Card className="glass">
               <CardHeader className="pb-3">
                 <h3 className="text-lg font-semibold flex items-center gap-2">


### PR DESCRIPTION
## Summary
- update the ticket assignment handler so User-role requests using the multi-assignee payload can self-assign when every assignee ID matches the requester
- gate the ticket detail self-assignment card so it only appears when a ticket currently has no assignees

## Testing
- pnpm --filter web lint *(fails: existing parser errors across the web package)*

------
https://chatgpt.com/codex/tasks/task_e_68ddca219ea4832eb93e7eed139cfed8